### PR TITLE
Use 'piksi' data format as default

### DIFF
--- a/peregrine/samples.py
+++ b/peregrine/samples.py
@@ -13,7 +13,7 @@ import numpy as np
 
 __all__ = ['load_samples', 'save_samples']
 
-def load_samples(filename, num_samples=-1, num_skip=0, file_format='int8'):
+def load_samples(filename, num_samples=-1, num_skip=0, file_format='piksi'):
   """
   Load sample data from a file.
 


### PR DESCRIPTION
Use 'piksi' data format for raw samples by default instead of 'int8', so Peregrine is by default compatible with piksi_sample_grabber.
