### PR TITLE
Installs Cython via pip rather than via the package manager

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -16,7 +16,6 @@ function install_deps_debian () {
          build-essential \
          python-numpy \
          python-dev \
-         cython \
          python-cython \
          python-dev
     git submodule update --init


### PR DESCRIPTION
The Cython version needs to be >=0.22 because libswiftnav requires that. If Cython is installed via the systems package manager, an outdated version might be installed. Cython is required in the `requirements.txt` file, so it will be installed via pip. This patch removes Cython from the `apt-get` list.