### PR TITLE
updates documentation to tell type of argument

### DIFF
--- a/peregrine/samples.py
+++ b/peregrine/samples.py
@@ -25,7 +25,7 @@ def load_samples(filename, num_samples=-1, num_skip=0, file_format='piksi'):
     Number of samples to read, ``-1`` means the whole file.
   num_skip : int, optional
     Number of samples to discard from the beginning of the file.
-  file_format : {'int8'}, optional
+  file_format : string, optional
     Format of the sample data file. Takes one of the following values:
       * `'int8'` : Binary file consisting of a packed array of 8-bit signed
         integers.


### PR DESCRIPTION
It looks like the `{'int8'}` was still there from before bf5621cabe783125c9dc2804f9f50c43843a8281 in which the default format was changed to `piksi`.