### PR TITLE
tests OS version before trying to add Ubuntu Precise PPA

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -6,7 +6,12 @@ function install_deps_debian () {
     # Sudo'd version of travis installation instructions
     sudo apt-get update -qq
     sudo apt-get install python-software-properties
-    sudo add-apt-repository --yes ppa:kalakris/cmake
+    if [[ $(source /etc/os-release;echo $ID) == "ubuntu" ]]; then
+        if [[ $(source /etc/os-release;echo $VERSION_ID) == "12.04" ]]; then
+	    # If this is Ubuntu 12.04 install updated cmake
+            sudo add-apt-repository --yes ppa:kalakris/cmake
+        fi
+    fi
     sudo apt-get update -qq
     sudo apt-get -y install cmake \
          check \


### PR DESCRIPTION
The kalakris/cmake PPA only works on Ubuntu Precise (12.04). If the script is executed on other systems it will fail. The change tests for the OS version before trying to add the PPA. The cmake (version 2.8.12.2) that comes with Ubuntu 14.04 seems to be sufficient for the the install process.