### PR TITLE
Fix L1CA & L2C false lock detector

### DIFF
--- a/peregrine/alias_detector.py
+++ b/peregrine/alias_detector.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2016 Swift Navigation Inc.
+# Contact: Adel Mamin <adel.mamin@exafore.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import numpy as np
+from swiftnav.track import AliasDetector as AD
+from peregrine import defaults
+from peregrine import gps_constants
+
+
+class AliasDetector(object):
+
+  def __init__(self, coherent_ms):
+    """
+    Initialize the parameters, which are common across different
+    types of tracking channels.
+
+    Parameters
+    ----------
+    coherent_ms : int
+      Coherent integration time [ms].
+
+
+    """
+    self.first_step = True
+    self.err_hz = 0.
+    self.coherent_ms = coherent_ms
+    self.iterations_num = coherent_ms / defaults.alias_detect_slice_ms
+
+  def reinit(self, coherent_ms):
+    """
+    Customize the alias detect reinitialization in a subclass.
+    The method can be optionally redefined in a subclass to perform
+    a subclass specific actions to happen when alias detect
+    reinitialization procedure happens.
+
+    Parameters
+    ----------
+    coherent_ms : int
+      Coherent integration time [ms].
+
+    """
+    self.err_hz = 0
+    self.coherent_ms = coherent_ms
+    self.alias_detect.reinit(self.integration_rounds, time_diff=2e-3)
+
+  def preprocess(self):
+    """
+    Customize the alias detect procedure in a subclass.
+    The method can be optionally redefined in a subclass to perform
+    a subclass specific actions to happen before correlator runs
+    next integration round.
+
+    """
+    self.first_step = True
+    return self.iterations_num, self.chips_num
+
+  def postprocess(self, P):
+    """
+    Customize the alias detect run procedure in a subclass.
+    The method can be optionally redefined in a subclass to perform
+    a subclass specific actions to happen after correlator runs
+    next integration round.
+
+    Parameters
+    ----------
+    P : prompt I/Q
+      The prompt I/Q samples from correlator.
+    code_phase : current code phase [chips]
+
+    """
+
+  def postprocess(self, P):
+    if self.first_step:
+      self.alias_detect.first(P.real, P.imag)
+    else:
+      self.err_hz = self.alias_detect.second(P.real, P.imag)
+      abs_err_hz = abs(self.err_hz)
+      err_sign = np.sign(self.err_hz)
+      # The expected frequency errors are +-(25 + N * 50) Hz
+      # For the reference, see:
+      # https://swiftnav.hackpad.com/Alias-PLL-lock-detector-in-L2C-4fWUJWUNnOE
+      if abs_err_hz > 25.:
+        self.err_hz = 25
+        self.err_hz += 50 * int((abs_err_hz - 25) / 50)
+        abs_err_hz -= self.err_hz
+        if abs_err_hz + 25. > 50.:
+          self.err_hz += 50
+      elif abs_err_hz > 25 / 2.:
+        self.err_hz = 25
+      else:
+        self.err_hz = 0
+      self.err_hz *= err_sign
+
+    self.first_step = not self.first_step
+
+    return self.chips_num
+
+  def get_err_hz(self):
+    """
+    Customize the alias detect get error procedure in a subclass.
+
+    """
+    return self.err_hz
+
+
+class AliasDetectorL1CA(AliasDetector):
+
+  def __init__(self, coherent_ms):
+
+    AliasDetector.__init__(self, coherent_ms)
+
+    self.chips_num = gps_constants.chips_per_code
+    self.integration_rounds = defaults.alias_detect_interval_ms / \
+        (defaults.alias_detect_slice_ms * 2)
+
+    self.alias_detect = AD(acc_len=self.integration_rounds, time_diff=2e-3)
+
+
+class AliasDetectorL2C(AliasDetector):
+
+  def __init__(self, coherent_ms):
+
+    AliasDetector.__init__(self, coherent_ms)
+
+    self.chips_num = 2 * gps_constants.l2_cm_chips_per_code / coherent_ms
+    self.integration_rounds = defaults.alias_detect_interval_ms / \
+        (defaults.alias_detect_slice_ms * 2)
+
+    self.alias_detect = AD(acc_len=self.integration_rounds, time_diff=2e-3)

--- a/peregrine/defaults.py
+++ b/peregrine/defaults.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Swift Navigation Inc.
+# Copyright (C) 2014,2016 Swift Navigation Inc.
 # Contact: Adel Mamin <adelm@exafore.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
@@ -21,7 +21,7 @@ processing_block_size = int(20e6)  # [samples]
 
 # used to simulate real HW
 # [0..10230]
-l2c_short_step_chips = 500  # used to simulate real HW
+l2c_short_step_chips = 300  # used to simulate real HW
 
 chipping_rate = 1.023e6  # Hz
 code_length = 1023  # chips
@@ -264,7 +264,16 @@ l2c_lock_detect_params_20ms = {
     'lp': 50,      # 1000ms worth of I/Q samples to reach pessimistic lock
     'lo': 240}     # 4800ms worth of I/Q samples to lower optimistic lock
 
+# The time interval, over which the alias detection is done.
+# The alias detect algorithm averages the phase angle over this time [ms]
 alias_detect_interval_ms = 500
+
+# The correlator intermediate results are read with this timeout in [ms].
+# The intermediate results are the input for the alias lock detector.
+alias_detect_slice_ms = 1
 
 # Default pipelining prediction coefficient
 pipelining_k = .9549
+
+# Default coherent integration time for L2C tracker
+l2c_coherent_integration_time_ms = 20

--- a/peregrine/tracking.py
+++ b/peregrine/tracking.py
@@ -420,7 +420,7 @@ class TrackingChannel(object):
         coherent_iter, code_chips_to_integrate = self._short_n_long_preprocess()
       else:
         coherent_iter, code_chips_to_integrate = \
-          self.alias_detector.preprocess()
+            self.alias_detector.preprocess()
         self.E = self.P = self.L = 0.j
 
       # Estimated blksize might change as a result of a change of
@@ -474,13 +474,13 @@ class TrackingChannel(object):
 
       # Update PLL lock detector
       self.lock_detect_outo, \
-      self.lock_detect_outp, \
-      lock_detect_pcount1, \
-      lock_detect_pcount2, \
-      lock_detect_lpfi, \
-      lock_detect_lpfq = self.lock_detect.update(self.P.real,
-                                                 self.P.imag,
-                                                 coherent_iter)
+          self.lock_detect_outp, \
+          lock_detect_pcount1, \
+          lock_detect_pcount2, \
+          lock_detect_lpfi, \
+          lock_detect_lpfq = self.lock_detect.update(self.P.real,
+                                                     self.P.imag,
+                                                     coherent_iter)
 
       self.loop_filter.update(self.E, self.P, self.L)
       self.track_result.coherent_ms[self.i] = self.coherent_ms
@@ -566,7 +566,7 @@ class TrackingChannelL1CA(TrackingChannel):
     params['chipping_rate'] = gps_constants.l1ca_chip_rate
     params['sample_index'] = params['samples']['sample_index']
     params['alias_detector'] = \
-      alias_detector.AliasDetectorL1CA(params['coherent_ms'])
+        alias_detector.AliasDetectorL1CA(params['coherent_ms'])
 
     TrackingChannel.__init__(self, params)
 
@@ -760,13 +760,13 @@ class TrackingChannelL2C(TrackingChannel):
       # L2C CM code is only half of the PRN code length.
       # The other half is CL code. Thus multiply by 2.
       self.code_chips_to_integrate = \
-        int(2 * defaults.l2c_short_step_chips)
+          int(2 * defaults.l2c_short_step_chips)
     else:
       # L2C CM code is only half of the PRN code length.
       # The other half is CL code. Thus multiply by 2.
       self.code_chips_to_integrate = \
-        2 * gps_constants.l2_cm_chips_per_code - \
-        self.code_chips_to_integrate
+          2 * gps_constants.l2_cm_chips_per_code - \
+          self.code_chips_to_integrate
     code_chips_to_integrate = self.code_chips_to_integrate
 
     return self.coherent_iter, code_chips_to_integrate
@@ -894,8 +894,8 @@ class Tracker(object):
       self.samples_to_track = self.ms_to_track * sampling_freq / 1e3
       if samples['samples_total'] < self.samples_to_track:
         logger.warning(
-          "Samples set too short for requested tracking length (%.4fs)"
-          % (self.ms_to_track * 1e-3))
+            "Samples set too short for requested tracking length (%.4fs)"
+            % (self.ms_to_track * 1e-3))
         self.samples_to_track = samples['samples_total']
     else:
       self.samples_to_track = samples['samples_total']
@@ -975,8 +975,8 @@ class Tracker(object):
     if self.pbar:
       self.pbar.finish()
     res = map(lambda chan: chan.track_result.makeOutputFileNames(
-                chan.output_file),
-                self.tracking_channels)
+        chan.output_file),
+        self.tracking_channels)
 
     fn_analysis = map(lambda x: x[0], res)
     fn_results = map(lambda x: x[1], res)
@@ -1197,13 +1197,13 @@ class TrackResults:
     with open(fn_analysis, mode) as f1:
       if self.print_start:
         f1.write(
-          "sample_index,ms_tracked,coherent_ms,IF,doppler_phase,carr_doppler,"
-          "code_phase,code_freq,"
-          "CN0,E_I,E_Q,P_I,P_Q,L_I,L_Q,"
-          "lock_detect_outp,lock_detect_outo,"
-          "lock_detect_pcount1,lock_detect_pcount2,"
-          "lock_detect_lpfi,lock_detect_lpfq,alias_detect_err_hz,"
-          "code_phase_acc\n")
+            "sample_index,ms_tracked,coherent_ms,IF,doppler_phase,carr_doppler,"
+            "code_phase,code_freq,"
+            "CN0,E_I,E_Q,P_I,P_Q,L_I,L_Q,"
+            "lock_detect_outp,lock_detect_outo,"
+            "lock_detect_pcount1,lock_detect_pcount2,"
+            "lock_detect_lpfi,lock_detect_lpfq,alias_detect_err_hz,"
+            "code_phase_acc\n")
       for i in range(size):
         f1.write("%s," % int(self.absolute_sample[i]))
         f1.write("%s," % self.ms_tracked[i])


### PR DESCRIPTION
The fix allows to detect the false lock condition. The condition and the implementation approach are described in https://swiftnav.hackpad.com/Alias-PLL-lock-detector-in-L2C-4fWUJWUNnOE.

The PR is contingent on the PR https://github.com/swift-nav/libswiftnav/pull/363, which should be merged first.
